### PR TITLE
support evid=8(overwrite).

### DIFF
--- a/ev_manager.hpp
+++ b/ev_manager.hpp
@@ -98,6 +98,11 @@ namespace torsten {
           id = 2;
         }
         break;
+      case 8:                   // mrgsolve: "evid=9" overwrite cmt
+        if (event_his.cmt(i) > 0) {
+          id = 6;
+        }
+        break;
       default:
         if (event_his.is_ss_dosing(i)) {
           if (event_his.ss(i) == 2) {

--- a/event.hpp
+++ b/event.hpp
@@ -63,6 +63,10 @@ namespace torsten {
         model.solve(y, t0, t1, force, integ);
         y(cmt - 1) = 0;
         break;
+      case 6:
+        model.solve(y, t0, t1, force, integ);
+        y(cmt - 1) = jp;
+        break;
       default:
         model.solve(y, t0, t1, force, integ);
         y(cmt - 1) += jp;
@@ -112,6 +116,14 @@ namespace torsten {
           y = torsten::mpi::precomputed_gradients(yd, vt);
         }
         y(cmt - 1) = 0;
+        break;
+      case 6:
+        vt = pmx_model_vars<model_t>::vars(t1, y, force, model.par());
+        if (t1 > t0) {
+          yd = model_solve_d(model, y, t0, t1, force, integ, model_pars...);
+          y = torsten::mpi::precomputed_gradients(yd, vt);
+        }
+        y(cmt - 1) = jp;
         break;
       default:
         vt = pmx_model_vars<model_t>::vars(t1, y, force, model.par());


### PR DESCRIPTION
Address https://github.com/metrumresearchgroup/torsten_math/issues/1

Internally this type of events corresponds to event object type id=6.